### PR TITLE
Fix issue with gencl77 failing for examples in CAS book (Computationa…

### DIFF
--- a/gencl77.f
+++ b/gencl77.f
@@ -2129,10 +2129,11 @@
 ! Local variables
 !
       CHARACTER*3 CH3, ELC(NELS)
-      INTEGER I, J, K, L, MARK, MC, N, NP, PP(NCFG), QA(NELS), QC(NELS),
-     &        QQ
+      INTEGER I, J, K, L, MARK, MC, N, NP/0/, PP(NCFG), QA(NELS), 
+     &        QC(NELS), QQ
       INTEGER LVAL
       EXTERNAL LVAL
+      SAVE NP
 !
 
 


### PR DESCRIPTION
Fix issue with gencl77 failing for examples in CAS book (Computational Atomic Structure: An MCHF Approach, by C. Fischer, T. Brage, and P. Jonsson): Table 4.2 (p. 72) and Table 7.6 (p. 142). The variable NP in subroutine REPLAC needs to be static and initialized to zero.
